### PR TITLE
Convert string to camel case

### DIFF
--- a/camel-case/camelCase.js
+++ b/camel-case/camelCase.js
@@ -4,7 +4,7 @@ function toCamelCase(str){
   
   const divided = str.split(regex);
 
-  for ( let i = 1; i < divided.length; i++) {
+  for (let i = 1; i < divided.length; i++) {
     divided[i] = divided[i].replace(divided[i][0], divided[i][0].toUpperCase());
   }
 

--- a/camel-case/camelCase.js
+++ b/camel-case/camelCase.js
@@ -1,0 +1,14 @@
+function toCamelCase(str){
+
+  const regex = /[\-]|[\_]/g;
+  
+  const divided = str.split(regex);
+
+  for ( let i = 1; i < divided.length; i++) {
+    divided[i] = divided[i].replace(divided[i][0], divided[i][0].toUpperCase());
+  }
+
+  return divided.join('');
+}
+
+toCamelCase("A-B-C");


### PR DESCRIPTION
Complete the method/function so that it converts dash/underscore delimited words into camel casing. The first word within the output should be capitalized only if the original word was capitalized (known as Upper Camel Case, also often referred to as Pascal case).

Examples
```
toCamelCase("the-stealth-warrior") // returns "theStealthWarrior"

toCamelCase("The_Stealth_Warrior") // returns "TheStealthWarrior"
```